### PR TITLE
setup.py fixes

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 vtk
 pygmsh==5.0.2
 meshio==2.3.10
+scipy==1.4.1

--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,7 @@ with open(path.join(SETUP_DIR, 'README.md'), 'r', errors = 'ignore') as f:
 # we're using setup() in the first place.  This code avoids eval, for security.
 
 version = {}
-with open(path.join(SETUP_DIR, 'gillespy2/__version__.py')) as f:
+with open(path.join(SETUP_DIR, 'spatialpy/__version__.py')) as f:
     text = f.read().rstrip().splitlines()
     vars = [line for line in text if line.startswith('__') and '=' in line]
     for v in vars:


### PR DESCRIPTION
- Fix a line in setup.py that caused build to fail
- Add scipy as a dependency to requirements.txt (import spatialpy was failing in a fresh python env)